### PR TITLE
Kite sense patch 1

### DIFF
--- a/new/ALU.v
+++ b/new/ALU.v
@@ -94,7 +94,7 @@ reg [31:0] Hard_result;
 always @* begin
     case(ALU_control)
         4'b0111 : Hard_result = imme; // lui
-        4'b1010 : Hard_result = $signed(imme) + $signed(Read_data1); // auipc
+        4'b1010 : Hard_result = $signed(imme) + $signed(pc_out); // auipc
     endcase
 end
 // ############################################################

--- a/new/imm_gen.v
+++ b/new/imm_gen.v
@@ -14,12 +14,12 @@ module imm_gen(
         end
         // I_type:arith
         else if(in[6:0] == 7'b0010011) begin
-            // if (in[31:25] == 7'b0000000 || in[31:25] == 7'b0100000) begin
-            //     imm = {27'b0,in[24:20]}; // shift part
-            // end
-            // else begin
+            if (in[14:12] == 3'b001 || in[14:12] == 3'b101) begin
+                imm = {27'b0, in[24:20]};
+            end 
+            else begin
                 imm = {{20{in[31]}}, in[31:20]}; // other part
-            // end
+            end
         end
         // I_type:jalr
         else if(in[6:0] == 7'b1100111) begin


### PR DESCRIPTION
auipc's second operand should be pc_out and improve the immediate generator of I_type: arith